### PR TITLE
Change the label for zz captions to English

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1416,6 +1416,15 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (!closedCaptionsInfo) {
         return;
       }
+      // NYM - if we have a "zz" caption option from backlot, catch it here
+      // and at least change the label to English
+      if (closedCaptionsInfo.languages && closedCaptionsInfo.locale) {
+        for (var i = 0; i < closedCaptionsInfo.languages.length; i++) {
+          if (closedCaptionsInfo.languages[i] === 'zz') {
+            closedCaptionsInfo.locale['zz'] = 'English';
+          }
+        }
+      }
       // Load the CC info for the video with the given id onto the state
       this.state.closedCaptionOptions.availableLanguages = closedCaptionsInfo;
       if (this.state.closedCaptionOptions.enabled) {


### PR DESCRIPTION
Ooyala Backlot is not currently handling the language of VTT caption files correctly - they are received with a language of "zz". This is a stopgap until support is fixed, to display "zz" caption options as "English" in the UI.