### PR TITLE
toggle closed caption view on muted audio

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -185,6 +185,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.mb.subscribe(OO.EVENTS.CLOSED_CAPTION_CUE_CHANGED, "customerUi", _.bind(this.onClosedCaptionCueChanged, this));
         this.mb.subscribe(OO.EVENTS.CHANGE_CLOSED_CAPTION_LANGUAGE, 'customerUi', _.bind(this.onChangeClosedCaptionLanguage, this));
         this.mb.subscribe(OO.EVENTS.VOLUME_CHANGED, "customerUi", _.bind(this.onVolumeChanged, this));
+        // NYM – sync closed caption viewability with muted audio
+        this.mb.subscribe(OO.EVENTS.VOLUME_CHANGED, "customerUi", _.bind(this.nymOnVolumeChangedToggleClosedCaptions, this));
         this.mb.subscribe(OO.EVENTS.VC_VIDEO_ELEMENT_IN_FOCUS, "customerUi", _.bind(this.onVideoElementFocus, this));
         this.mb.subscribe(OO.EVENTS.REPLAY, "customerUi", _.bind(this.onReplay, this));
         this.mb.subscribe(OO.EVENTS.ASSET_DIMENSION, "customerUi", _.bind(this.onAssetDimensionsReceived, this));
@@ -401,6 +403,16 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.state.volumeState.volume = newVolume;
       }
       this.renderSkin();
+    },
+
+    // NYM – enable closed captions when volume is off, or disable closed captions when volume is on
+    // for v4 players that default to displaying closed captions if available
+    nymOnVolumeChangedToggleClosedCaptions: function (event, newVolue) {
+      this.state.persistentSettings.closedCaptionOptions['enabled']
+      if ((newVolue <= 0 && !this.state.closedCaptionOptions.enabled)
+        || (newVolue > 0 && this.state.closedCaptionOptions.enabled)) {
+        this.toggleClosedCaptionEnabled();
+      }
     },
 
     resetUpNextInfo: function (purge) {


### PR DESCRIPTION
Ooyala videos with non-muted audio will not display CCs. When audio is turned off the CCs will display.

[Trello](https://trello.com/c/R6e2N39e/28-only-display-closed-captions-when-user-s-volume-is-off)